### PR TITLE
Fix compilation errors when building with Qt 6.2.3

### DIFF
--- a/src/plugins/tts/osx/qtexttospeech_osx.mm
+++ b/src/plugins/tts/osx/qtexttospeech_osx.mm
@@ -189,7 +189,7 @@ bool QTextToSpeechEngineOsx::setVolume(double volume)
 QLocale localeForVoice(NSString *voice)
 {
     NSDictionary *attrs = [NSSpeechSynthesizer attributesForVoice:voice];
-    return QString::fromNSString(attrs[NSVoiceLocaleIdentifier]);
+    return QLocale(QString::fromNSString(attrs[NSVoiceLocaleIdentifier]));
 }
 
 QVoice QTextToSpeechEngineOsx::voiceForNSVoice(NSString *voiceString) const

--- a/src/plugins/tts/sapi/qtexttospeech_sapi.h
+++ b/src/plugins/tts/sapi/qtexttospeech_sapi.h
@@ -37,6 +37,7 @@
 #ifndef QTEXTTOSPEECHENGINE_SAPI_H
 #define QTEXTTOSPEECHENGINE_SAPI_H
 
+#include <windows.h>
 #include <QtCore/qt_windows.h>
 #include <sapi.h>
 


### PR DESCRIPTION
Greetings!

I'm currently building qtspeech, on a system which has Qt 6.2.3, which I believe is the latest stable version as of when I'm opening this PR.

There are a couple of compilation errors.

Here are some suggested fixes.

I'm creating this PR based on the `6.2.3` branch, as that's the version of Qt that I'm using to build. I had more errors building against the `dev` branch, which I won't get into here (some errors about plugin classes). I don't know which version of Qt is required to build the `dev` branch.

One error appears on all the platforms I tested (mac, linux, windows), and one is just on windows.

----

:one: First error: 

Fix compilation error casting `QString` to `QLocale`.

When building qtspeech against Qt 6.2.3, we see the below compilation error.

```
qtexttospeech_osx.mm:192:12: error: no viable conversion from returned value of type 'QString' to function return type 'QLocale'
    return QString::fromNSString(attrs[NSVoiceLocaleIdentifier]);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jdoe/dev/Qt/6.2.3/macos/lib/QtCore.framework/Headers/qlocale.h:930:5: note: candidate constructor not viable: no known conversion from 'QString' to 'QLocale::Language' for 1st argument
    QLocale(Language language, Script script = AnyScript, Territory territory = AnyTerritory);
    ^   
/Users/jdoe/dev/Qt/6.2.3/macos/lib/QtCore.framework/Headers/qlocale.h:931:5: note: candidate constructor not viable: no known conversion from 'QString' to 'const QLocale &' for 1st argument
    QLocale(const QLocale &other);
    ^   
/Users/jdoe/dev/Qt/6.2.3/macos/lib/QtCore.framework/Headers/qlocale.h:1129:5: note: candidate constructor not viable: no known conversion from 'QString' to 'QLocalePrivate &' for 1st argument
    QLocale(QLocalePrivate &dd);
    ^   
/Users/jdoe/dev/Qt/6.2.3/macos/lib/QtCore.framework/Headers/qlocale.h:928:14: note: explicit constructor is not a candidate
    explicit QLocale(const QString &name);
             ^   
1 error generated.
```

To prevent this error, use the `QLocale(QString)` constructor.


---

:two: Second error

When building qtspeech against Qt 6.2.3, mingw_64, we see the below compilation error.

```
In file included from C:/Qt/Tools/mingw900_64/x86_64-w64-mingw32/include/windows.h:72,
                 from C:/Qt/6.2.3/mingw_64/include/QtCore/qt_windows.h:64,
                 from qtexttospeech_sapi.h:40,
                 from qtexttospeech_sapi.cpp:37:
C:/Qt/Tools/mingw900_64/x86_64-w64-mingw32/include/winuser.h:2965:43: error: variable 'CreateSyntheticPointerDevice' definition is marked dllimport
 2965 | WINUSERAPI HSYNTHETICPOINTERDEVICE WINAPI CreateSyntheticPointerDevice(POINTER_INPUT_TYPE pointerType, ULONG maxCount, POINTER_FEEDBACK_MODE mode);
      |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:/Qt/Tools/mingw900_64/x86_64-w64-mingw32/include/winuser.h:2965:72: error: 'POINTER_INPUT_TYPE' was not declared in this scope; did you mean 'PRINTER_FONTTYPE'?
 2965 | WINUSERAPI HSYNTHETICPOINTERDEVICE WINAPI CreateSyntheticPointerDevice(POINTER_INPUT_TYP
 pointerType, ULONG maxCount, POINTER_FEEDBACK_MODE mode);
      |                                                                        ^~~~~~~~~~~~~~~~~
      |                                                                        PRINTER_FONTTYPE
C:/Qt/Tools/mingw900_64/x86_64-w64-mingw32/include/winuser.h:2965:110: error: expected primary-expression before 'maxCount'
 2965 | WINUSERAPI HSYNTHETICPOINTERDEVICE WINAPI CreateSyntheticPointerDevice(POINTER_INPUT_TYPE pointerType, ULONG maxCount, POINTER_FEEDBACK_MODE mode);
      |                                                                                                              ^~~~~~~~
C:/Qt/Tools/mingw900_64/x86_64-w64-mingw32/include/winuser.h:2965:120: error: 'POINTER_FEEDBACK_MODE' was not declared in this scope
 2965 | WINUSERAPI HSYNTHETICPOINTERDEVICE WINAPI CreateSyntheticPointerDevice(POINTER_INPUT_TYPE pointerType, ULONG maxCount, POINTER_FEEDBACK_MODE mode);
      |                                                                                                                        ^~~~~~~~~~~~~~~~~~~~~
C:/Qt/Tools/mingw900_64/x86_64-w64-mingw32/include/winuser.h:2965:146: error: expression list treated as compound expression in initializer [-fpermissive]
 2965 | WINUSERAPI HSYNTHETICPOINTERDEVICE WINAPI CreateSyntheticPointerDevice(POINTER_INPUT_TYPE pointerType, ULONG maxCount, POINTER_FEEDBACK_MODE mode);
      |                                                                                                                                                  ^
C:/Qt/Tools/mingw900_64/x86_64-w64-mingw32/include/winuser.h:2966:93: error: 'POINTER_TYPE_INFO' does not name a type; did you mean 'POINTER_64_INT'?
 2966 | WINUSERAPI WINBOOL WINAPI InjectSyntheticPointerInput(HSYNTHETICPOINTERDEVICE device, CONST POINTER_TYPE_INFO* pointerInfo, UINT32 count);
      |                                                                                             ^~~~~~~~~~~~~~~~~
      |                                                                                             POINTER_64_INT
```

Based on a tip mentioned in a related issue [QTEXT-14](https://bugreports.qt.io/projects/QTEXT/issues/QTEXT-14), workaround this by including `windows.h`, before including `qt_windows.h`.

☝️ Note that `src/plugins/tts/winrt/qtexttospeech_winrt.h` also includes `qt_windows.h`.  I didn't see any compilation errors for that, but I think the `winrt` project wasn't compiled at all on my machine. 